### PR TITLE
Add caching and async features

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ llm-orchestration
   - `log_message`: Logs messages for tracking.
   - `validate_input`: Validates input data for the pipeline.
 
+### New Features
+- **Response caching**: `LLMCallStep` can persist responses to disk to avoid repeated API calls.
+- **Asynchronous pipeline**: `AsyncDataPipeline` runs steps concurrently when supported.
+- **Vector store**: `VectorStore` allows embeddings to be persisted and queried using FAISS.
+- **Data validation & logging**: `DataPipeline` automatically validates inputs and logs each step.
+- **Summarization step**: `SummarizationStep` generates a report for the entire DataFrame.
+- **Plugin architecture**: additional `PipelineStep` classes can be discovered from a plugin directory.
+
 ## Testing
 The project includes a set of basic test cases located in the `tests` directory to ensure the functionality of the `LLMPipeline` class.
 

--- a/llm_pipeline/plugin_loader.py
+++ b/llm_pipeline/plugin_loader.py
@@ -1,0 +1,26 @@
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import List, Type
+
+from .pipeline import PipelineStep
+
+
+def load_plugins(plugin_dir: str) -> List[Type[PipelineStep]]:
+    """Load PipelineStep subclasses from a directory."""
+    steps: List[Type[PipelineStep]] = []
+    path = Path(plugin_dir)
+    if not path.exists():
+        return steps
+    for file in path.glob("*.py"):
+        spec = importlib.util.spec_from_file_location(file.stem, file)
+        if not spec or not spec.loader:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[file.stem] = module
+        spec.loader.exec_module(module)
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, PipelineStep) and obj is not PipelineStep:
+                steps.append(obj)
+    return steps

--- a/llm_pipeline/vector_store.py
+++ b/llm_pipeline/vector_store.py
@@ -1,0 +1,41 @@
+import os
+import pickle
+from typing import List, Iterable
+
+import faiss
+import numpy as np
+
+class VectorStore:
+    """Simple FAISS-based vector store for embeddings."""
+
+    def __init__(self, dim: int, store_path: str | None = None):
+        self.dim = dim
+        self.index = faiss.IndexFlatL2(dim)
+        self.ids: List[str] = []
+        self.store_path = store_path
+        if store_path and os.path.exists(store_path):
+            with open(store_path, "rb") as f:
+                self.ids, index_data = pickle.load(f)
+                self.index = faiss.deserialize_index(index_data)
+
+    def add(self, ids: Iterable[str], embeddings: Iterable[List[float]]):
+        vecs = np.array(list(embeddings)).astype('float32')
+        self.index.add(vecs)
+        self.ids.extend(list(ids))
+        self._save()
+
+    def query(self, embedding: List[float], k: int = 5):
+        vec = np.array([embedding]).astype('float32')
+        distances, idx = self.index.search(vec, k)
+        results = []
+        for i, dist in zip(idx[0], distances[0]):
+            if i < len(self.ids):
+                results.append((self.ids[i], float(dist)))
+        return results
+
+    def _save(self):
+        if not self.store_path:
+            return
+        data = faiss.serialize_index(self.index)
+        with open(self.store_path, "wb") as f:
+            pickle.dump((self.ids, data), f)

--- a/plugins/example_plugin.py
+++ b/plugins/example_plugin.py
@@ -1,0 +1,7 @@
+from llm_pipeline.pipeline import PipelineStep
+import pandas as pd
+
+class ExamplePluginStep(PipelineStep):
+    def process(self, df: pd.DataFrame) -> pd.DataFrame:
+        df['plugin'] = 'loaded'
+        return df


### PR DESCRIPTION
## Summary
- support caching and async in `LLMCallStep`
- add `AsyncDataPipeline`, a parallel pipeline runner
- provide `VectorStore` utility for storing/querying embeddings
- add `SummarizationStep` and plugin loader
- document new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff93097ec8331a1f9679f43494c3c