### PR TITLE
Add remote MCP tool discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ llm-orchestration
 - **Plugin architecture**: additional `PipelineStep` classes can be discovered from a plugin directory.
 - **Agentic goal step**: `AgenticGoalStep` now supports multi-step tool use and can load built-in MCP tools for advanced agent behavior.
 - **MCP servers**: remote MCP servers can be listed for use by `AgenticGoalStep` to augment local tools.
+- **MCP tool discovery**: `AgenticGoalStep` automatically queries remote MCP servers for available tools when possible.
 
 ## Testing
 The project includes a set of basic test cases located in the `tests` directory to ensure the functionality of the `LLMPipeline` class.

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,6 +1,8 @@
-"""Simple MCP tools for the agentic pipeline."""
+"""Utilities and built-in tools for MCP integration."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Callable
+
+import logging
 
 
 def uppercase(
@@ -27,3 +29,42 @@ MCP_TOOLS = {
     "uppercase": uppercase,
     "char_count": char_count,
 }
+
+
+def discover_remote_tools(server_url: str) -> Dict[str, Callable[[Dict[str, Any], Dict[str, Any] | None], Dict[str, Any]]]:
+    """Return tool callables discovered from an MCP server.
+
+    The server is expected to expose a ``/tools`` endpoint returning a JSON
+    mapping of tool names to descriptions. Each discovered tool is invoked by
+    sending the context to ``POST {server_url}/<tool_name>``.
+    """
+
+    try:
+        import requests
+
+        resp = requests.get(f"{server_url.rstrip('/')}/tools", timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logging.debug("failed to discover MCP tools from %s: %s", server_url, exc)
+        return {}
+
+    tools: Dict[str, Callable[[Dict[str, Any], Dict[str, Any] | None], Dict[str, Any]]] = {}
+    if isinstance(data, dict):
+        for name, desc in data.items():
+            url = f"{server_url.rstrip('/')}/{name}"
+
+            def call(context: Dict[str, Any], args: Dict[str, Any] | None = None, *, _url=url) -> Dict[str, Any]:
+                try:
+                    payload = {"context": context, "args": args or {}}
+                    resp = requests.post(_url, json=payload, timeout=10)
+                    resp.raise_for_status()
+                    return resp.json()
+                except Exception as exc:  # pragma: no cover - network errors
+                    logging.debug("mcp tool %s failed: %s", _url, exc)
+                    return {"error": str(exc)}
+
+            call.__doc__ = desc
+            tools[name] = call
+
+    return tools

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -154,12 +154,26 @@ class TestAgenticStep(unittest.TestCase):
         import threading, json
 
         class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/tools":
+                    tools = {"echo": "echo back"}
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps(tools).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
             def do_POST(self):
                 length = int(self.headers.get("Content-Length", 0))
                 body = self.rfile.read(length)
                 data = json.loads(body)
                 context = data.get("context", {})
-                result = {**context, "server": "called"}
+                if self.path == "/echo":
+                    result = {**context, "server": "called"}
+                else:
+                    result = {"error": "unknown"}
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()


### PR DESCRIPTION
## Summary
- enhance MCP module with `discover_remote_tools`
- automatically fetch remote tools in `AgenticGoalStep`
- support specifying MCP endpoints for tool discovery
- document new capability in README
- update tests for new discovery behavior

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600b4ab8348331a762df5fba3985d6