### PR TITLE
Switch from prints to logging

### DIFF
--- a/llm_pipeline/llm_methods.py
+++ b/llm_pipeline/llm_methods.py
@@ -6,6 +6,9 @@ from sklearn.cluster import DBSCAN
 from dotenv import load_dotenv
 from math import ceil
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -23,8 +26,8 @@ def openai_embedding_function(text: str) -> List[float]:
             model="text-embedding-3-small"
         )
         return response.data[0].embedding
-    except Exception as e:
-        print("Error generating embedding:", e)
+    except Exception:
+        logger.exception("Error generating embedding")
         return []
 
 # ------------------------------------------------------------------

--- a/llm_pipeline/pipeline.py
+++ b/llm_pipeline/pipeline.py
@@ -8,7 +8,10 @@ import hashlib
 import numpy as np
 import json
 import asyncio
+import logging
 from tools.utils import log_message, validate_input
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -214,7 +217,7 @@ def openai_embedding_function(text: str) -> List[float]:
         response = client.embeddings.create(input=text, model="text-embedding-3-small")
         return response.data[0].embedding
     except Exception as e:
-        print("Error generating embedding:", e)
+        logger.exception("Error generating embedding")
         return []
 
 

--- a/monster_pipeline/create_embeddings.py
+++ b/monster_pipeline/create_embeddings.py
@@ -1,12 +1,15 @@
 import pandas as pd
 from llm_pipeline.pipeline import GenerateEmbeddingsStep, DataPipeline
 import csv
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Load test data from CSV file into a DataFrame
 try:
     df = pd.read_csv('./data/test_data_pipeline.csv', quoting=csv.QUOTE_ALL)
 except pd.errors.ParserError as e:
-    print(f"Error reading CSV file: {e}")
+    logger.error("Error reading CSV file: %s", e)
     raise
 
 # Define a couple of processing steps.
@@ -23,6 +26,5 @@ pipeline = DataPipeline(steps=[gen_embed])
 # Run the pipeline on the DataFrame.
 processed_df = pipeline.run(df)
 count = len(processed_df)
-
-print(f"Processed record count: {count}")
+logger.info("Processed record count: %s", count)
 processed_df.to_pickle('./data/monsters_with_embeddings.pkl')

--- a/monster_pipeline/query_process.py
+++ b/monster_pipeline/query_process.py
@@ -1,6 +1,9 @@
 import pandas as pd
 from llm_pipeline.pipeline import DataPipeline, kNNFilterStep, LLMCallWithDataFrame
 import csv
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 # Reload the DataFrame.
@@ -19,7 +22,7 @@ pipeline = DataPipeline(steps=[knn_filter])
 # Run the pipeline on the DataFrame.
 processed_df = pipeline.run(reloaded_df)
 
-print(processed_df[['id', 'title']].to_string())
+logger.info(processed_df[['id', 'title']].to_string())
 
 llm_eval = LLMCallWithDataFrame(
     prompt_template="""What UI updates are being preformed?  Ignore records that not UI updates'.
@@ -27,4 +30,4 @@ llm_eval = LLMCallWithDataFrame(
     {record_details}""",
     fields=["title", "description", "acceptance_criteria"],
 )
-print(llm_eval.call_llm(processed_df))
+logger.info(llm_eval.call_llm(processed_df))

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,5 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def log_message(message):
-    print(f"[LOG] {message}")
+    """Log a simple message using the module logger."""
+    logger.info(message)
 
 def validate_input(data, expected_type):
     if not isinstance(data, expected_type):


### PR DESCRIPTION
## Summary
- use logging in utils
- log embedding errors instead of printing
- log status in pipeline scripts

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860114a86ac833183257d2082969bd9