### PR TITLE
Use logging instead of prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ llm-orchestration
 ### Utilities
 - **Module**: `tools`
 - **Functions**:
-  - `log_message`: Logs messages for tracking.
+  - `log_message`: Uses Python's ``logging`` library to record progress.
   - `validate_input`: Validates input data for the pipeline.
 
 ### New Features

--- a/examples/monster_pipeline/create_embeddings.py
+++ b/examples/monster_pipeline/create_embeddings.py
@@ -1,12 +1,16 @@
 import pandas as pd
 from llm_pipeline.pipeline import GenerateEmbeddingsStep, DataPipeline
 import csv
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 # Load test data from CSV file into a DataFrame
 try:
     df = pd.read_csv('./data/test_data_pipeline.csv', quoting=csv.QUOTE_ALL)
 except pd.errors.ParserError as e:
-    print(f"Error reading CSV file: {e}")
+    logger.error("Error reading CSV file: %s", e)
     raise
 
 # Define a couple of processing steps.
@@ -24,5 +28,5 @@ pipeline = DataPipeline(steps=[gen_embed])
 processed_df = pipeline.run(df)
 count = len(processed_df)
 
-print(f"Processed record count: {count}")
+logger.info("Processed record count: %s", count)
 processed_df.to_pickle('./data/monsters_with_embeddings.pkl')

--- a/examples/monster_pipeline/query_process.py
+++ b/examples/monster_pipeline/query_process.py
@@ -1,6 +1,10 @@
 import pandas as pd
 from llm_pipeline.pipeline import DataPipeline, kNNFilterStep, LLMCallWithDataFrame
 import csv
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 # Reload the DataFrame.
@@ -19,7 +23,7 @@ pipeline = DataPipeline(steps=[knn_filter])
 # Run the pipeline on the DataFrame.
 processed_df = pipeline.run(reloaded_df)
 
-print(processed_df[['id', 'title']].to_string())
+logger.info("%s", processed_df[['id', 'title']].to_string())
 
 llm_eval = LLMCallWithDataFrame(
     prompt_template="""What UI updates are being preformed?  Ignore records that not UI updates'.
@@ -27,4 +31,4 @@ llm_eval = LLMCallWithDataFrame(
     {record_details}""",
     fields=["title", "description", "acceptance_criteria"],
 )
-print(llm_eval.call_llm(processed_df))
+logger.info("%s", llm_eval.call_llm(processed_df))

--- a/llm_pipeline/llm_methods.py
+++ b/llm_pipeline/llm_methods.py
@@ -6,6 +6,9 @@ from sklearn.cluster import DBSCAN
 from dotenv import load_dotenv
 from math import ceil
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -23,8 +26,8 @@ def openai_embedding_function(text: str) -> List[float]:
             model="text-embedding-3-small"
         )
         return response.data[0].embedding
-    except Exception as e:
-        print("Error generating embedding:", e)
+    except Exception as e:  # pragma: no cover - network errors
+        logger.error("Error generating embedding: %s", e)
         return []
 
 # ------------------------------------------------------------------

--- a/llm_pipeline/pipeline.py
+++ b/llm_pipeline/pipeline.py
@@ -8,7 +8,10 @@ import hashlib
 import numpy as np
 import json
 import asyncio
+import logging
 from tools.utils import log_message, validate_input
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -213,8 +216,8 @@ def openai_embedding_function(text: str) -> List[float]:
     try:
         response = client.embeddings.create(input=text, model="text-embedding-3-small")
         return response.data[0].embedding
-    except Exception as e:
-        print("Error generating embedding:", e)
+    except Exception as e:  # pragma: no cover - network errors
+        logger.error("Error generating embedding: %s", e)
         return []
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,9 +1,17 @@
 """Utility functions for logging and input validation."""
 
+from __future__ import annotations
 
-def log_message(message):
-    """Print a message with a log prefix."""
-    print(f"[LOG] {message}")
+import logging
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def log_message(message: str) -> None:
+    """Log a message with an ``INFO`` level."""
+    logger.info(message)
 
 def validate_input(data, expected_type):
     """Validate that ``data`` is an instance of ``expected_type``."""


### PR DESCRIPTION
## Summary
- replace all `print` calls with Python's `logging` module
- update example scripts to log progress
- document logging in README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860146f1068833196a96efaedd8ca8f