### PR TITLE
Add starter knowledge dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ llm-orchestration
 - **MCP tool discovery**: `AgenticGoalStep` automatically queries remote MCP servers for available tools when possible.
 - **Knowledge server**: `knowledge_server` provides a minimal MCP server with a
   persistent knowledge store. It answers simple questions and falls back to
-  deterministic responses when `OPENAI_API_KEY` is not set.
+  deterministic responses when `OPENAI_API_KEY` is not set. A starter dataset of
+  basic facts is available in `knowledge_server/basic_knowledge.json` and can be
+  loaded when starting the server:
+
+```python
+from knowledge_server import run_server
+server, thread = run_server(path="knowledge_server/basic_knowledge.json")
+```
 
 ## Testing
 The project includes a set of basic test cases located in the `tests` directory to ensure the functionality of the `LLMPipeline` class.

--- a/knowledge_server/basic_knowledge.json
+++ b/knowledge_server/basic_knowledge.json
@@ -1,0 +1,13 @@
+{
+  "human": [["isa", "mammal"], ["needs", "food"], ["needs", "water"], ["needs", "shelter"]],
+  "dog": [["isa", "mammal"], ["needs", "food"], ["needs", "water"]],
+  "cat": [["isa", "mammal"], ["needs", "food"], ["needs", "water"]],
+  "mammal": [["isa", "animal"], ["needs", "food"], ["needs", "water"]],
+  "animal": [["needs", "food"], ["needs", "water"]],
+  "plant": [["needs", "water"], ["needs", "sunlight"]],
+  "tree": [["isa", "plant"]],
+  "bird": [["isa", "animal"], ["needs", "food"], ["needs", "water"]],
+  "fish": [["isa", "animal"], ["needs", "water"], ["needs", "food"]],
+  "sunflower": [["isa", "plant"], ["needs", "sunlight"], ["needs", "water"]],
+  "car": [["needs", "fuel"]]
+}

--- a/tests/test_knowledge_server.py
+++ b/tests/test_knowledge_server.py
@@ -38,3 +38,18 @@ def test_add_and_query():
     assert resp.json().get("answer") == "food"
 
     stop_test_server(server, thread)
+
+
+def test_load_basic_knowledge_and_query(tmp_path):
+    file_path = tmp_path / "basic.json"
+    file_path.write_text(json.dumps({"plant": [["needs", "water"]]}))
+
+    server, thread = start_test_server(path=str(file_path))
+    url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+
+    resp = requests.post(
+        f"{url}/query", json={"text": "What does a plant need?"}, timeout=5
+    )
+    assert resp.json().get("answer") == "water"
+
+    stop_test_server(server, thread)


### PR DESCRIPTION
## Summary
- provide a small JSON file with basic facts for the knowledge server
- document how to load the starter facts
- test loading knowledge from a file

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686025c87cc08331b78c8028ad7a329a