### PR TITLE
Improve logging and plugin loading

### DIFF
--- a/examples/monster_pipeline/create_embeddings.py
+++ b/examples/monster_pipeline/create_embeddings.py
@@ -6,27 +6,31 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Load test data from CSV file into a DataFrame
-try:
-    df = pd.read_csv('./data/test_data_pipeline.csv', quoting=csv.QUOTE_ALL)
-except pd.errors.ParserError as e:
-    logger.error("Error reading CSV file: %s", e)
-    raise
 
-# Define a couple of processing steps.
+def main() -> None:
+    """Generate embeddings for the monster dataset."""
 
-# Generate one embedding from title & description.
-gen_embed = GenerateEmbeddingsStep(
-    output_key="embedding_title_desc",
-    fields=["title", "description"]
-)
+    # Load test data from CSV file into a DataFrame
+    try:
+        df = pd.read_csv('./data/test_data_pipeline.csv', quoting=csv.QUOTE_ALL)
+    except pd.errors.ParserError as e:
+        logger.error("Error reading CSV file: %s", e)
+        raise
 
-# Create the pipeline with all steps.
-pipeline = DataPipeline(steps=[gen_embed])
+    # Generate one embedding from title & description.
+    gen_embed = GenerateEmbeddingsStep(
+        output_key="embedding_title_desc",
+        fields=["title", "description"]
+    )
 
-# Run the pipeline on the DataFrame.
-processed_df = pipeline.run(df)
-count = len(processed_df)
+    pipeline = DataPipeline(steps=[gen_embed])
 
-logger.info("Processed record count: %s", count)
-processed_df.to_pickle('./data/monsters_with_embeddings.pkl')
+    processed_df = pipeline.run(df)
+    count = len(processed_df)
+
+    logger.info("Processed record count: %s", count)
+    processed_df.to_pickle('./data/monsters_with_embeddings.pkl')
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/monster_pipeline/query_process.py
+++ b/examples/monster_pipeline/query_process.py
@@ -3,32 +3,33 @@ from llm_pipeline.llm_methods import DataPipeline, kNNFilterStep, LLMCallWithDat
 import csv
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 
-# Reload the DataFrame.
-reloaded_df = pd.read_pickle('./data/monsters_with_embeddings.pkl')
+def main() -> None:
+    """Query the vector store and evaluate results."""
 
-# Use a kNN filter on one of the embeddings:
-knn_filter = kNNFilterStep(
-    query="input form",
-    k=3,
-    embedding_column="embedding_title_desc"
-)
+    reloaded_df = pd.read_pickle('./data/monsters_with_embeddings.pkl')
 
-# Create the pipeline with all steps.
-pipeline = DataPipeline(steps=[knn_filter])
+    knn_filter = kNNFilterStep(
+        query="input form",
+        k=3,
+        embedding_column="embedding_title_desc",
+    )
 
-# Run the pipeline on the DataFrame.
-processed_df = pipeline.run(reloaded_df)
+    pipeline = DataPipeline(steps=[knn_filter])
+    processed_df = pipeline.run(reloaded_df)
 
-logger.info("%s", processed_df[['id', 'title']].to_string())
+    logger.info("%s", processed_df[['id', 'title']].to_string())
 
-llm_eval = LLMCallWithDataFrame(
-    prompt_template="""What UI updates are being preformed?  Ignore records that not UI updates'.
+    llm_eval = LLMCallWithDataFrame(
+        prompt_template="""What UI updates are being preformed?  Ignore records that not UI updates'.
 
     {record_details}""",
-    fields=["title", "description", "acceptance_criteria"],
-)
-logger.info("%s", llm_eval.call_llm(processed_df))
+        fields=["title", "description", "acceptance_criteria"],
+    )
+    logger.info("%s", llm_eval.call_llm(processed_df))
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_pipeline/plugin_loader.py
+++ b/llm_pipeline/plugin_loader.py
@@ -14,11 +14,12 @@ def load_plugins(plugin_dir: str) -> List[Type[PipelineStep]]:
     if not path.exists():
         return steps
     for file in path.glob("*.py"):
-        spec = importlib.util.spec_from_file_location(file.stem, file)
+        module_name = f"plugin_{file.stem}"
+        spec = importlib.util.spec_from_file_location(module_name, file)
         if not spec or not spec.loader:
             continue
         module = importlib.util.module_from_spec(spec)
-        sys.modules[file.stem] = module
+        sys.modules[module_name] = module
         spec.loader.exec_module(module)
         for name, obj in inspect.getmembers(module, inspect.isclass):
             if issubclass(obj, PipelineStep) and obj is not PipelineStep:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A reusable library for LLM-based pipelines."
 authors = [{name = "Bob Foreman"}]
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
     "pandas",
     "openai",

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- raise python version requirement to 3.10
- remove logging.basicConfig from utils
- guard example scripts with `__main__`
- log cache errors and offline fallback in `LLMCallStep`
- log MCP discovery failures
- avoid plugin module name collisions

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ad0ba4fc833198ad4139ba49f22d