### PR TITLE
Add Joust wrap-around example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ llm-orchestration
 │   ├── test_data_pipeline.csv
 │   └── test_data_pipeline_embeddings.pkl
 ├── examples
-│   └── monster_pipeline
+│   ├── monster_pipeline
+│   └── joust_game
 ├── AGENTS.md
 ├── requirements.txt
 ├── requirements-dev.txt
@@ -105,6 +106,13 @@ replace `faiss-cpu` with `faiss-gpu`.
 
 ## Usage
 After setting up the project, you can use the `DataPipeline` or `DataFrameProcessor` classes from `llm_pipeline.llm_methods` to process data through the LLM pipeline. Refer to the individual module documentation for more details on usage.
+
+## Joust Game Example
+An additional example in `examples/joust_game` demonstrates a simple horizontal
+movement simulation inspired by the classic Joust game. The player's speed starts
+30% faster than the enemy and decreases by 5% with each level. Both the player
+and enemy wrap around the screen horizontally, while enemies maintain their
+movement direction when wrapping.
 
 ## Contributing
 Contributions are welcome! Please submit a pull request or open an issue for any enhancements or bug fixes.

--- a/examples/joust_game/joust.py
+++ b/examples/joust_game/joust.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+
+@dataclass
+class Player:
+    """Represents the player character."""
+    x: float
+    speed: float
+
+
+@dataclass
+class Enemy:
+    """Represents a single enemy."""
+    x: float
+    speed: float
+    direction: str  # 'left' or 'right'
+
+
+class JoustGame:
+    """Simple Joust-like horizontal movement simulation."""
+
+    def __init__(self, width: int, enemy_speed: float = 5.0, level: int = 1):
+        self.width = width
+        self.enemy_speed = enemy_speed
+        self.level = level
+        self.player_speed = 0.0
+        self.update_player_speed()
+        self.player = Player(x=width / 2, speed=self.player_speed)
+        self.enemy = Enemy(x=0.0, speed=self.enemy_speed, direction="right")
+
+    def update_player_speed(self) -> None:
+        """Calculate player speed relative to the enemy."""
+        diff = 0.30 - 0.05 * (self.level - 1)
+        if diff < 0:
+            diff = 0
+        self.player_speed = self.enemy_speed * (1 + diff)
+
+    def wrap_position(self, x: float) -> float:
+        """Wrap a position around the screen width."""
+        if x < 0:
+            return self.width + x
+        if x >= self.width:
+            return x - self.width
+        return x
+
+    def move_player(self, direction: str) -> None:
+        """Move the player left or right with wrap-around."""
+        if direction == "left":
+            self.player.x -= self.player.speed
+        else:
+            self.player.x += self.player.speed
+        self.player.x = self.wrap_position(self.player.x)
+
+    def move_enemy(self) -> None:
+        """Move the enemy in its set direction with wrap-around."""
+        if self.enemy.direction == "left":
+            self.enemy.x -= self.enemy.speed
+            if self.enemy.x < 0:
+                self.enemy.x = self.wrap_position(self.enemy.x)
+        else:
+            self.enemy.x += self.enemy.speed
+            if self.enemy.x >= self.width:
+                self.enemy.x = self.wrap_position(self.enemy.x)
+

--- a/tests/test_joust.py
+++ b/tests/test_joust.py
@@ -1,0 +1,30 @@
+import unittest
+from examples.joust_game.joust import JoustGame
+
+
+class TestJoustGame(unittest.TestCase):
+    def test_speed_difference(self):
+        game = JoustGame(width=100, enemy_speed=10, level=1)
+        self.assertAlmostEqual(game.player_speed, 13.0)
+        game.level = 2
+        game.update_player_speed()
+        self.assertAlmostEqual(game.player_speed, 12.5)
+        game.level = 7
+        game.update_player_speed()
+        self.assertAlmostEqual(game.player_speed, 10.0)
+
+    def test_wrap_and_direction(self):
+        game = JoustGame(width=100, enemy_speed=10, level=1)
+        game.player.x = 95
+        game.move_player("right")
+        self.assertAlmostEqual(game.player.x, 8.0)
+        game.enemy.x = 95
+        game.enemy.direction = "right"
+        game.move_enemy()
+        self.assertAlmostEqual(game.enemy.x, 5.0)
+        self.assertEqual(game.enemy.direction, "right")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add a simple Joust-like game example
- unit test the new game logic
- document the new example in README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688b02452c8331b7506a44dd165899