### PR TITLE
Add Chroma ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ llm-orchestration
 - **Asynchronous pipeline**: `AsyncDataPipeline` runs steps concurrently when supported.
 - **RAG tools**: `rag_tools` can chunk text files, build a vector store using LlamaIndex, and query it.
 - **Vector store**: `VectorStore` allows embeddings to be persisted and queried using FAISS.
+- **Chroma ingest**: `ChromaIngestPipeline` stores text file chunks with embeddings in a Chroma vector store.
 - **Data validation & logging**: `DataPipeline` automatically validates inputs and logs each step.
 - **Summarization step**: `SummarizationStep` generates a report for the entire DataFrame.
 - **Plugin architecture**: additional `PipelineStep` classes can be discovered from a plugin directory.

--- a/rag_tools.py
+++ b/rag_tools.py
@@ -109,6 +109,8 @@ class rag_tools:
         overlap: int = 0,
     ) -> VectorStoreIndex:
         """Create a ``VectorStoreIndex`` from ``source`` and persist it."""
+        if os.path.isfile(store_path):
+            os.remove(store_path)
         df = self.chunk_text(source, chunk_size=chunk_size, overlap=overlap)
         Settings.embed_model = self._embed_model()
         Settings.llm = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 requests
 faiss-cpu
 llama-index
+chromadb

--- a/tests/test_chroma_ingest.py
+++ b/tests/test_chroma_ingest.py
@@ -1,0 +1,29 @@
+import unittest
+import tempfile
+from pathlib import Path
+
+from chroma_ingest import ChromaIngestPipeline
+
+
+class TestChromaIngest(unittest.TestCase):
+    def test_ingest_and_query(self):
+        with tempfile.TemporaryDirectory() as td:
+            data_dir = Path(td) / "data"
+            data_dir.mkdir()
+            file_path = data_dir / "sample.txt"
+            file_path.write_text("Alpha one. Beta two.")
+
+            pipeline = ChromaIngestPipeline()
+            store_path = Path(td) / "store"
+            pipeline.ingest_folder(str(data_dir), str(store_path), chunk_size=12)
+
+            self.assertTrue((store_path / "chroma.sqlite3").exists())
+            self.assertTrue(Path(str(store_path) + ".csv").exists())
+
+            result = pipeline.query_store("Beta two", str(store_path), k=1)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result.iloc[0]["filename"], "sample.txt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `ChromaIngestPipeline` demo class for ingesting text files into Chroma
- cover Chroma ingestion with new unit test
- allow rag_tools to overwrite file paths
- document new capability in README
- install chromadb

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858750a22c833198413d04e9891e89